### PR TITLE
WPZ-2: Adding instant search

### DIFF
--- a/apps/okreads-e2e/src/specs/search-books.spec.ts
+++ b/apps/okreads-e2e/src/specs/search-books.spec.ts
@@ -16,12 +16,17 @@ describe('When: Use the search feature', () => {
     expect(items.length).toBeGreaterThan(1);
   });
 
-  xit('Then: I should see search results as I am typing', async () => {
+  it('Then: I should see search results as I am typing', async () => {
     await browser.get('/');
     await browser.wait(
       ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
     );
 
-    // TODO: Implement this test!
+    const form = await $('form');
+    const input = await $('input[type="search"]');
+    await input.sendKeys('javascript');
+
+    const items = await $$('[data-testing="book-item"]');
+    expect(items.length).toBeGreaterThan(1);
   });
 });

--- a/libs/books/data-access/src/lib/+state/books.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/books.effects.spec.ts
@@ -3,6 +3,7 @@ import { createBook, SharedTestingModule } from '@tmo/shared/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { ReplaySubject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 import { TestBed } from '@angular/core/testing';
 
 import { searchBooks, searchBooksSuccess } from './books.actions';
@@ -32,7 +33,9 @@ describe('BooksEffects', () => {
       actions = new ReplaySubject();
       actions.next(searchBooks({ term: '' }));
 
-      effects.searchBooks$.subscribe((action) => {
+      effects.searchBooks$
+      .pipe(debounceTime(500))
+      .subscribe((action) => {
         expect(action).toEqual(
           searchBooksSuccess({ books: [createBook('A')] })
         );

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -2,12 +2,12 @@
   role="search"
   aria-label="Books"
   [formGroup]="searchForm"
-  (submit)="searchBooks()"
 >
   <mat-form-field floatLabel="never">
     <input
       autoFocus
       matInput
+      (keyup)="searchBooks()"
       type="search"
       title="Search field"
       [attr.aria-label]="'Search for ' + searchTerm + ' in books.'"


### PR DESCRIPTION
**Requirements**

> As a user, I want to see book results as I am typing in the search field -- I don't want to have to submit the form.

- [x] Starting from the `chore/code-review` branch from Task 1, create a new branch `feat/instant-search`.
- [x] Update the code to provide instant search results as the user is typing. 
- [x] Be sure not to spam the API with too many calls -- no more than one request every 500 ms.
- [x] Open the e2e test file `apps/okreads-e2e/src/specs/search-books.spec.ts`. Enable the second spec by renaming `xit` to `it`, then implement the test to ensure instant search works.
- [x] Commit your changes to the feature branch
- [x] Open a pull-request with `chore/code-review` as the target.
- [ ] Merge a pull-request with `chore/code-review` as the target.
- [ ] Delete source branch (optional).