### PR TITLE
WPZ-2: Adding instant search

### DIFF
--- a/apps/okreads-e2e/src/specs/search-books.spec.ts
+++ b/apps/okreads-e2e/src/specs/search-books.spec.ts
@@ -16,12 +16,23 @@ describe('When: Use the search feature', () => {
     expect(items.length).toBeGreaterThan(1);
   });
 
-  xit('Then: I should see search results as I am typing', async () => {
+  it('Then: I should see search results as I am typing', async () => {
     await browser.get('/');
     await browser.wait(
       ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
     );
 
-    // TODO: Implement this test!
+    const input = await $('input[type="search"]');
+    await input.sendKeys('javascript');
+    let items = await $$('[data-testing="book-item"]');
+    expect(items.length).toBeGreaterThan(1);
+
+    await input.sendKeys('');
+    items = await $$('[data-testing="book-item"]');
+    expect(items.length).toBeLessThanOrEqual(0);
+
+    await input.sendKeys('apple');
+    items = await $$('[data-testing="book-item"]');
+    expect(items.length).toBeLessThanOrEqual(0);
   });
 });

--- a/libs/books/data-access/src/lib/+state/books.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/books.effects.spec.ts
@@ -32,7 +32,8 @@ describe('BooksEffects', () => {
       actions = new ReplaySubject();
       actions.next(searchBooks({ term: '' }));
 
-      effects.searchBooks$.subscribe((action) => {
+      effects.searchBooks$
+      .subscribe((action) => {
         expect(action).toEqual(
           searchBooksSuccess({ books: [createBook('A')] })
         );

--- a/libs/books/data-access/src/lib/+state/books.effects.ts
+++ b/libs/books/data-access/src/lib/+state/books.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { catchError, debounceTime, map, switchMap } from 'rxjs/operators';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Book } from '@tmo/shared/models';
 import { searchBooks, searchBooksFailure, searchBooksSuccess } from './books.actions';
@@ -11,6 +11,7 @@ import { searchBooks, searchBooksFailure, searchBooksSuccess } from './books.act
 export class BooksEffects {
   searchBooks$ = createEffect(() =>
     this.actions$.pipe(
+      debounceTime(500),
       ofType(searchBooks),
       switchMap((action) =>
         this.http.get<Book[]>(`/api/books/search?q=${action.term}`).pipe(

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -2,12 +2,12 @@
   role="search"
   aria-label="Books"
   [formGroup]="searchForm"
-  (submit)="searchBooks()"
 >
   <mat-form-field floatLabel="never">
     <input
       autoFocus
       matInput
+      (keyup)="searchBooks()"
       type="search"
       title="Search field"
       [attr.aria-label]="'Search for ' + searchTerm + ' in books.'"


### PR DESCRIPTION
> As a user, I want to see book results as I am typing in the search field -- I don't want to have to submit the form.

- [x] Starting from the `chore/code-review` branch from Task 1, create a new branch `feat/instant-search`.
- [x] Update the code to provide instant search results as the user is typing. 
- [x] Be sure not to spam the API with too many calls -- no more than one request every 500 ms.
- [x] Open the e2e test file `apps/okreads-e2e/src/specs/search-books.spec.ts`. Enable the second spec by renaming `xit` to `it`, then implement the test to ensure instant search works.
- [x] Commit your changes to the feature branch
- [x] Open a pull-request with `chore/code-review` as the target.
- [ ] Merge a pull-request with `chore/code-review` as the target.
- [ ] Delete source branch (optional).