### PR TITLE
WPZ-3: Undo add and remove from reading list

### DIFF
--- a/apps/okreads-e2e/src/specs/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/specs/reading-list.spec.ts
@@ -1,4 +1,4 @@
-import { $, browser, ExpectedConditions } from 'protractor';
+import { $, $$, browser, by, element, ExpectedConditions, protractor } from 'protractor';
 
 describe('When: I use the reading list feature', () => {
   it('Then: I should see my reading list', async () => {
@@ -16,5 +16,108 @@ describe('When: I use the reading list feature', () => {
         'My Reading List'
       )
     );
+  });
+  it('Then: I should be able to add book to reading list', async () => {
+    await browser.get('/');
+    await browser.wait(
+      ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
+    );
+    const form = await $('form');
+    const input = await $('input[type="search"]');
+    await input.sendKeys('javascript');
+    await form.submit();
+    await browser.sleep(1000);
+    let readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    let items = await $$('[data-testing="reading-list-item"]');
+    const countItemsBefore = items.length;
+    await browser
+      .actions()
+      .sendKeys(protractor.Key.ESCAPE)
+      .perform();
+
+    const button = await $$('[data-testing="want-to-read-button"]:not(:disabled)');
+    await button[0].click();
+
+    readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    items = await $$('[data-testing="reading-list-item"]');
+    expect(items.length).toBeGreaterThan(countItemsBefore);
+  });
+  it('Then: I should be able to remove book from reading list', async () => {
+    await browser.get('/');
+    await browser.wait(
+      ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
+    );
+
+    const readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    let items = await $$('[data-testing="reading-list-item"]');
+    const countItemsBefore = items.length;
+    const buttonRemove = await $$('[data-testing="remove-book-button"]');
+    await buttonRemove[buttonRemove.length-1].click();
+
+    items = await $$('[data-testing="reading-list-item"]');
+    expect(items.length).toBeLessThan(countItemsBefore);
+  });
+});
+describe('When: I use the undo feature', () => {
+  it('Then: I should be able to undo adding book to reading list', async () => {
+    await browser.get('/');
+    await browser.wait(
+      ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
+    );
+    // Open reading list
+    let readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    // Get initial number of reading items
+    let items = await $$('[data-testing="reading-list-item"]');
+    const countItemsBefore = items.length;
+    // Press ESC to close reading list
+    await browser
+      .actions()
+      .sendKeys(protractor.Key.ESCAPE)
+      .perform();
+    // Perform search and get results on screen
+    const form = await $('form');
+    const input = await $('input[type="search"]');
+    await input.sendKeys('javascript');
+    await form.submit();
+    await browser.sleep(1000);
+    // Click first enabled Want to read button
+    const button = await $$('[data-testing="want-to-read-button"]:not(:disabled)');
+    await button[0].click();
+    // Click on Undo in SnackBar.
+    await browser.sleep(1000);
+    const submit = await browser.driver.findElement(by.css('.mat-simple-snackbar-action'));
+    await submit.click();
+    // Open reading list
+    readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    // Check number of reading list items is same as before
+    items = await $$('[data-testing="reading-list-item"]');
+    expect(items.length).toEqual(countItemsBefore);
+  });
+  it('Then: I should be able to undo book removal from reading list', async () => {
+    await browser.get('/');
+    await browser.wait(
+      ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
+    );
+    // Open reading list
+    const readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    // Get initial number of reading items
+    let items = await $$('[data-testing="reading-list-item"]');
+    const countItemsBefore = items.length;
+    // Click on remove from reading list button
+    const buttonRemove = await $$('[data-testing="remove-book-button"]');
+    await buttonRemove[buttonRemove.length-1].click();
+    // Click on Undo in SnackBar
+    await browser.sleep(1000);
+    const submit = await browser.driver.findElement(by.css('.mat-simple-snackbar-action'));
+    await submit.click();
+    // Check number of reading list items is same as before
+    items = await $$('[data-testing="reading-list-item"]');
+    expect(items.length).toEqual(countItemsBefore);
   });
 });

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -52,6 +52,7 @@
           <p [innerHTML]="b.description"></p>
           <div>
             <button
+              data-testing="want-to-read-button"
               mat-flat-button
               color="primary"
               [title]="'Add ' + b.title + ' to reading list.'"

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -1,14 +1,17 @@
+import { FormBuilder } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import {
   addToReadingList,
   clearSearch,
   getAllBooks,
+  removeFromReadingList,
   ReadingListBook,
   searchBooks,
 } from '@tmo/books/data-access';
-import { FormBuilder } from '@angular/forms';
-import { Book } from '@tmo/shared/models';
+import { convertBookToReadingListItem } from '@tmo/shared/testing';
+import { Book, UNDO_DURATION } from '@tmo/shared/models';
 
 @Component({
   selector: 'tmo-book-search',
@@ -24,7 +27,8 @@ export class BookSearchComponent implements OnInit {
 
   constructor(
     private readonly store: Store,
-    private readonly fb: FormBuilder
+    private readonly fb: FormBuilder,
+    private _snackBar: MatSnackBar
   ) {}
 
   get searchTerm(): string {
@@ -45,6 +49,17 @@ export class BookSearchComponent implements OnInit {
 
   addBookToReadingList(book: Book) {
     this.store.dispatch(addToReadingList({ book }));
+    this.openSnackBar('Added ' + book.title + ' to reading list!', 'Undo', book);
+  }
+
+  openSnackBar(message: string, action: string, book: Book) {
+    const duration = UNDO_DURATION;
+    const snackBarRef = this._snackBar.open(message, action, {
+      duration,
+    });
+    snackBarRef.onAction().subscribe(() => {
+      this.store.dispatch(removeFromReadingList({ item: convertBookToReadingListItem(book)}));
+    });
   }
 
   searchExample() {

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,5 +1,9 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <div class="reading-list-item" *ngFor="let b of readingList$ | async">
+  <div
+    data-testing="reading-list-item"
+    class="reading-list-item"
+    *ngFor="let b of readingList$ | async"
+  >
     <div>
       <img
         alt="Book cover illustration"
@@ -18,6 +22,7 @@
     <div>
       <button
         mat-button
+        data-testing="remove-book-button"
         color="warn"
         [title]="'Remove ' + b.title + ' from reading list.'"
         [attr.aria-label]="'Remove ' + b.title + ' from reading list.'"

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,18 +1,34 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import { addToReadingList, getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+import { convertReadingListItemToBook } from '@tmo/shared/testing';
+import { ReadingListItem, UNDO_DURATION } from '@tmo/shared/models';
 
 @Component({
   selector: 'tmo-reading-list',
   templateUrl: './reading-list.component.html',
   styleUrls: ['./reading-list.component.scss'],
 })
+
 export class ReadingListComponent {
   readingList$ = this.store.select(getReadingList);
 
-  constructor(private readonly store: Store) {}
+  constructor(private readonly store: Store, private _snackBar: MatSnackBar) {}
 
-  removeFromReadingList(item) {
+  removeFromReadingList(item: ReadingListItem) {
     this.store.dispatch(removeFromReadingList({ item }));
+    this.openSnackBar('Removed ' + item.title + ' from reading list!', 'Undo', item);
+  }
+
+  openSnackBar(message: string, action: string, item: ReadingListItem) {
+    const duration = UNDO_DURATION;
+    const snackBarRef = this._snackBar.open(message, action, {
+      duration,
+    });
+    snackBarRef.onAction().subscribe(() => {
+      this.store.dispatch(addToReadingList({ book: convertReadingListItemToBook(item) }));
+    });
   }
 }

--- a/libs/shared/models/src/models.ts
+++ b/libs/shared/models/src/models.ts
@@ -13,3 +13,5 @@ export interface ReadingListItem extends Omit<Book, 'id'> {
   finished?: boolean;
   finishedDate?: string;
 }
+
+export const UNDO_DURATION = 7000;

--- a/libs/shared/testing/src/lib/model-factories.ts
+++ b/libs/shared/testing/src/lib/model-factories.ts
@@ -21,3 +21,25 @@ export function createReadingListItem(bookId: string): ReadingListItem {
     publishedDate: new Date(2020, 0, 1).toISOString(),
   };
 }
+
+export function convertBookToReadingListItem({ id, title, description, authors, coverUrl, publishedDate}: Book): ReadingListItem {
+  return {
+    bookId: id,
+    title,
+    description,
+    authors,
+    coverUrl,
+    publishedDate,
+  };
+}
+
+export function convertReadingListItemToBook({ bookId, title, description, authors, coverUrl, publishedDate}: ReadingListItem): Book {
+  return {
+    id: bookId,
+    title,
+    description,
+    authors,
+    coverUrl,
+    publishedDate,
+  };
+}


### PR DESCRIPTION
> As a user, I want to be able to quickly undo my action when clicking the `Want to Read` button in the book list, or the remove button in the reading list.
- [x] Starting from the `chore/code-review` branch from Task 1, create a new branch `feat/undo-actions`.
- [x] Update the code such that a [snackbar](https://material.angular.io/components/snack-bar/overview) appears whenever the user adds or removes a book. (Hint: this module is already installed and set up)
- [x] The snackbar must display the event that occurred (i.e. added/removed), and an `Undo` action.
- [x] When the user clicks `Undo` it should set the reading list state back to the previous state.
- [x] Write a new e2e test in `apps/okreads-e2e/src/specs/reading-list.spec.ts` to test the new undo feature.
- [x] Commit your changes on the feature branch.
- [x] Open a pull-request with `chore/code-review` as the target.