### PR TITLE
WPZ-4: Ability to mark a book as finished

### DIFF
--- a/apps/okreads-e2e/src/specs/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/specs/reading-list.spec.ts
@@ -1,4 +1,4 @@
-import { $, browser, ExpectedConditions } from 'protractor';
+import { $, $$, browser, by, ExpectedConditions, protractor } from 'protractor';
 
 describe('When: I use the reading list feature', () => {
   it('Then: I should see my reading list', async () => {
@@ -16,5 +16,43 @@ describe('When: I use the reading list feature', () => {
         'My Reading List'
       )
     );
+  });
+  it('Then: I should be able to mark book as finished', async () => {
+    await browser.get('/');
+    await browser.wait(
+      ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
+    );
+    // Search for books
+    const form = await $('form');
+    const input = await $('input[type="search"]');
+    await input.sendKeys('javascript');
+    await form.submit();
+    await browser.sleep(1000);
+    let readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    const items = await $$('[data-testing="reading-list-item"]');
+    const countItemsBefore = items.length;
+    await browser
+      .actions()
+      .sendKeys(protractor.Key.ESCAPE)
+      .perform();
+    // Add some available book to reading list
+    const button = await $$('[data-testing="want-to-read-button"]:not(:disabled)');
+    await button[0].click();
+    // Check book has been added to reading list
+    readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    const itemsAfter = await $$('[data-testing="reading-list-item"]');
+    expect(itemsAfter.length).toBeGreaterThan(countItemsBefore);
+    // Mark book as finished
+    let buttonFinished = await $$('[data-testing="finished-button"]');
+    expect(buttonFinished[buttonFinished.length-1].getAttribute('ng-reflect-color')).toEqual('primary');
+    const finishedDetails = await browser.driver.findElements(by.css('[data-testing="reading-list-item-details-finished"]'));
+    expect(finishedDetails[finishedDetails.length-1].getText()).toContain('Not yet read');
+    await buttonFinished[buttonFinished.length-1].click();
+    buttonFinished = await $$('[data-testing="finished-button"]');
+    expect(buttonFinished[buttonFinished.length-1].getAttribute('ng-reflect-color')).toEqual('accent');
+    const finishedDetailsAfter = await browser.driver.findElements(by.css('[data-testing="reading-list-item-details-finished"]'));
+    expect(finishedDetailsAfter[finishedDetailsAfter.length-1].getText()).toContain('Reading complete:');
   });
 });

--- a/libs/api/books/src/lib/reading-list.controller.ts
+++ b/libs/api/books/src/lib/reading-list.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
 import { Book } from '@tmo/shared/models';
 import { ReadingListService } from './reading-list.service';
 
@@ -19,5 +19,10 @@ export class ReadingListController {
   @Delete('/reading-list/:id')
   async removeFromReadingList(@Param() params) {
     return await this.readingList.removeBook(params.id);
+  }
+
+  @Get('/reading-list/:id/finished')
+  async markAsFinished(@Param() params) {
+    return await this.readingList.finishBook(params.id);
   }
 }

--- a/libs/api/books/src/lib/reading-list.service.ts
+++ b/libs/api/books/src/lib/reading-list.service.ts
@@ -28,4 +28,24 @@ export class ReadingListService {
       return list.filter((x) => x.bookId !== id);
     });
   }
+
+  async finishBook(id: string): Promise<void> {
+    const readingList = await this.getList();
+    readingList.forEach((item: ReadingListItem) => {
+      if (item.bookId === id) {
+        if (item.finished) {
+          item.finished = false;
+          item.finishedDate = '';
+        } else {
+          const today = new Date();
+        item.finishedDate = today.toISOString();
+        item.finished = true;
+        }
+      }
+    });
+
+    this.storage.update(() => {
+      return readingList;
+    });
+  }
 }

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -41,3 +41,18 @@ export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
   props<{ item: ReadingListItem }>()
 );
+
+export const markAsFinished = createAction(
+  '[Books Search Results] Mark as finished',
+  props<{ item: ReadingListItem }>()
+);
+
+export const failedMarkAsFinished = createAction(
+  '[Reading List API] Failed mark as finished',
+  props<{ item: ReadingListItem }>()
+);
+
+export const confirmedMarkAsFinished = createAction(
+  '[Reading List API] Confirmed mark as finished',
+  props<{ item: ReadingListItem }>()
+);

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -7,12 +7,15 @@ import { ReadingListItem } from '@tmo/shared/models';
 import {
   addToReadingList,
   confirmedAddToReadingList,
+  confirmedMarkAsFinished,
   confirmedRemoveFromReadingList,
   failedAddToReadingList,
+  failedMarkAsFinished,
   failedRemoveFromReadingList,
   init as ReadingListActionsInit,
   loadReadingListError,
   loadReadingListSuccess,
+  markAsFinished,
   removeFromReadingList,
 } from './reading-list.actions';
 
@@ -49,6 +52,18 @@ export class ReadingListEffects implements OnInitEffects {
         this.http.delete(`/api/reading-list/${item.bookId}`).pipe(
           map(() => confirmedRemoveFromReadingList({ item })),
           catchError(() => of(failedRemoveFromReadingList({ item })))
+        )
+      )
+    )
+  );
+
+  finishBook$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(markAsFinished),
+      concatMap(({ item }) =>
+        this.http.get(`/api/reading-list/${item.bookId}/finished`).pipe(
+          map(() => confirmedMarkAsFinished({ item })),
+          catchError(() => of(failedMarkAsFinished({ item })))
         )
       )
     )

--- a/libs/books/data-access/src/lib/+state/reading-list.reducer.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.reducer.spec.ts
@@ -1,7 +1,10 @@
 import {
+  addToReadingList,
   failedAddToReadingList,
   failedRemoveFromReadingList,
   loadReadingListSuccess,
+  markAsFinished,
+  removeFromReadingList,
 } from './reading-list.actions';
 import {
   initialState,
@@ -54,6 +57,56 @@ describe('Books Reducer', () => {
       const result: State = reducer(state, action);
 
       expect(result.ids).toEqual(['A', 'B']);
+    });
+
+    it('addToReadingList should add book to reading list', () => {
+      const action = addToReadingList({
+        book: createBook('C'),
+      });
+
+      const result: State = reducer(state, action);
+
+      expect(result.ids).toEqual(['A', 'B', 'C']);
+    });
+
+    it('removeFromReadingList should remove book from reading list', () => {
+      const action = removeFromReadingList({
+        item: createReadingListItem('B'),
+      });
+
+      const result: State = reducer(state, action);
+
+      expect(result.ids).toEqual(['A']);
+    });
+
+    it('markAsFinished should mark book as finished', () => {
+      const action = markAsFinished({
+        item: createReadingListItem('A'),
+      });
+
+      const result: State = reducer(state, action);
+      const [first] = Object.values(result.entities);
+      expect(first.finished).toBe(true);
+      expect(result.ids).toEqual(['A', 'B']);
+    });
+
+    it('markAsFinished should unmark book as finished', () => {
+      const mark = markAsFinished({
+        item: createReadingListItem('A'),
+      });
+
+      const resultMark: State = reducer(state, mark);
+      const [first] = Object.values(resultMark.entities);
+      expect(first.finished).toBe(true);
+      expect(resultMark.ids).toEqual(['A', 'B']);
+      const unmark = markAsFinished({
+        item: first,
+      });
+
+      const resultUnmark: State = reducer(state, unmark);
+      const [second] = Object.values(resultUnmark.entities);
+      expect(second.finished).toBe(false);
+      expect(resultUnmark.ids).toEqual(['A', 'B']);
     });
   });
 

--- a/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
@@ -7,8 +7,10 @@ import {
   loadReadingListSuccess,
   loadReadingListError,
   removeFromReadingList,
+  markAsFinished,
 } from './reading-list.actions';
 import { ReadingListItem } from '@tmo/shared/models';
+import { Update } from '@ngrx/entity/src/models';
 
 export const READING_LIST_FEATURE_KEY = 'readingList';
 
@@ -58,7 +60,17 @@ const readingListReducer = createReducer(
   ),
   on(removeFromReadingList, (state, action) =>
     readingListAdapter.removeOne(action.item.bookId, state)
-  )
+  ),
+  on(markAsFinished, (state, action) => {
+    const todoUpdate: Update<ReadingListItem> = {
+      id: action.item.bookId,
+      changes: {
+        finished: !action.item.finished,
+        finishedDate: action.item.finished ? '' : new Date().toISOString(),
+      },
+    };
+    return readingListAdapter.updateOne(todoUpdate, state);
+  })
 );
 
 export function reducer(state: State | undefined, action: Action) {

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -52,6 +52,7 @@
           <p [innerHTML]="b.description"></p>
           <div>
             <button
+              data-testing="want-to-read-button"
               mat-flat-button
               color="primary"
               [title]="'Add ' + b.title + ' to reading list.'"
@@ -59,7 +60,7 @@
               (click)="addBookToReadingList(b)"
               [disabled]="b.isAdded"
             >
-              Want to Read
+              {{ getButtonText(b) }}
             </button>
           </div>
         </div>

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -4,11 +4,12 @@ import {
   addToReadingList,
   clearSearch,
   getAllBooks,
+  getReadingList,
   ReadingListBook,
   searchBooks,
 } from '@tmo/books/data-access';
 import { FormBuilder } from '@angular/forms';
-import { Book } from '@tmo/shared/models';
+import { Book, ReadingListItem } from '@tmo/shared/models';
 
 @Component({
   selector: 'tmo-book-search',
@@ -17,6 +18,7 @@ import { Book } from '@tmo/shared/models';
 })
 export class BookSearchComponent implements OnInit {
   books: ReadingListBook[];
+  readingList: ReadingListItem[];
 
   searchForm = this.fb.group({
     term: '',
@@ -34,6 +36,9 @@ export class BookSearchComponent implements OnInit {
   ngOnInit(): void {
     this.store.select(getAllBooks).subscribe((books) => {
       this.books = books;
+    });
+    this.store.select(getReadingList).subscribe((readingList) => {
+      this.readingList = readingList;
     });
   }
 
@@ -58,5 +63,16 @@ export class BookSearchComponent implements OnInit {
     } else {
       this.store.dispatch(clearSearch());
     }
+  }
+
+  getButtonText(book: ReadingListBook) {
+    let text = 'Want to Read';
+    this.readingList.forEach((item: ReadingListItem) => {
+      if (item.bookId === book.id) {
+        text = item.finished ? 'Finished' : 'Want to Read';
+      }
+    });
+
+    return text;
   }
 }

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,5 +1,9 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <div class="reading-list-item" *ngFor="let b of readingList$ | async">
+  <div
+    data-testing="reading-list-item"
+    class="reading-list-item"
+    *ngFor="let b of readingList$ | async"
+  >
     <div>
       <img
         alt="Book cover illustration"
@@ -14,16 +18,34 @@
       <div class="reading-list-item-details-author">
         {{ b.authors.join(',') }}
       </div>
+      <div
+        class="reading-list-item-details-finished"
+        data-testing="reading-list-item-details-finished"
+      >
+        <em>{{ finishedText(b) }}</em>
+      </div>
     </div>
     <div>
       <button
-        mat-button
+        mat-icon-button
+        data-testing="finished-button"
+        [color]="getFinishedButtonColor(b)"
+        [title]="'Mark ' + b.title + ' as finished.'"
+        [attr.aria-label]="'Mark ' + b.title + ' as finished.'"
+        (click)="markAsFinished(b)"
+      >
+        <mat-icon>book</mat-icon>
+      </button>
+    </div>
+    <div>
+      <button
+        mat-icon-button
         color="warn"
         [title]="'Remove ' + b.title + ' from reading list.'"
         [attr.aria-label]="'Remove ' + b.title + ' from reading list.'"
         (click)="removeFromReadingList(b)"
       >
-        <mat-icon>remove_circle</mat-icon> Remove
+        <mat-icon>remove_circle</mat-icon>
       </button>
     </div>
   </div>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.scss
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.scss
@@ -45,3 +45,7 @@
   font-size: 1rem;
   color: $gray60;
 }
+
+.reading-list-item-details-finished {
+  font-size: 0.66rem;
+}

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,6 +1,11 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import {
+  getReadingList,
+  markAsFinished,
+  removeFromReadingList,
+} from '@tmo/books/data-access';
+import { ReadingListItem } from '@tmo/shared/models';
 
 @Component({
   selector: 'tmo-reading-list',
@@ -12,7 +17,25 @@ export class ReadingListComponent {
 
   constructor(private readonly store: Store) {}
 
-  removeFromReadingList(item) {
+  removeFromReadingList(item: ReadingListItem) {
     this.store.dispatch(removeFromReadingList({ item }));
+  }
+
+  markAsFinished(item: ReadingListItem) {
+    this.store.dispatch(markAsFinished({ item }));
+  }
+
+  getFinishedButtonColor(item: ReadingListItem) {
+    return item.finished ? 'accent' : 'primary';
+  }
+
+  formatISODate(strDate: string) {
+    return strDate.substring(0, 10);
+  }
+
+  finishedText(item: ReadingListItem) {
+    return item.finished
+      ? 'Reading complete: ' + this.formatISODate(item.finishedDate)
+      : 'Not yet read';
   }
 }


### PR DESCRIPTION
**Estimated time:** 2-4 hours

**Requirements**

> As a user, I want to be able to mark a book as finished in my reading list.

- [x] Starting from the `chore/code-review` branch from Task 1, create a new branch `feat/mark-as-read`.
- [x] Update the _api_ code to provide a new `PUT /api/reading-list/:id/finished` endpoint.
- [x] This endpoint should update the `finished` flag to `true`.
- [x] And set `finishedDate` as an ISO date string (e.g. `2020-01-01T00:00:00.000Z`).
- [x] Update the UI to allow user to mark a book as _finished_ from the reading list sidenav. 
- [x] Bonus points for a thoughtful UI/UX design for this feature
- [x] Indicate the book as finished in the sidenav, including the finished date.
- [x] The user can still remove the book from their reading list. 
- [x] Removing a book will reset the finished status (i.e. if they add the book back it will not be finished).
- [x] The `Want to Read` button should change to `Finished`.
- [x] Write new unit tests to test new mark as finished feature.
- [x] Write a new e2e test in `apps/okreads-e2e/src/specs/reading-list.spec.ts` to test the new mark as finished feature.
- [x] Commit your changes on the feature branch.
- [ ] Open a pull-request with `chore/code-review` as the target.